### PR TITLE
Ignore default value from `FlagProvider`

### DIFF
--- a/defaultProvider.go
+++ b/defaultProvider.go
@@ -14,9 +14,5 @@ type defaultProvider struct{}
 
 func (defaultProvider) Provide(field reflect.StructField, v reflect.Value, _ ...string) error {
 	valStr := getDefaultTag(field)
-	if len(valStr) == 0 {
-		return fmt.Errorf("defaultProvider: getDefaultTag returns empty value")
-	}
-
 	return SetField(field, v, valStr)
 }

--- a/defaultProvider.go
+++ b/defaultProvider.go
@@ -14,5 +14,9 @@ type defaultProvider struct{}
 
 func (defaultProvider) Provide(field reflect.StructField, v reflect.Value, _ ...string) error {
 	valStr := getDefaultTag(field)
+	if len(valStr) == 0 {
+		return fmt.Errorf("defaultProvider: getDefaultTag returns empty value")
+	}
+
 	return SetField(field, v, valStr)
 }

--- a/flagProvider.go
+++ b/flagProvider.go
@@ -101,7 +101,10 @@ func (fp flagProvider) Provide(field reflect.StructField, v reflect.Value, _ ...
 	}
 
 	val := fn()
-	return SetField(field, v, *val)
+	if *val != fd.defaultVal {
+		return SetField(field, v, *val)
+	}
+	return fmt.Errorf("flagProvider: value for key [%s] is same as default [%s], ignoring", fd.key, fd.defaultVal)
 }
 
 func getFlagData(field reflect.StructField) (*flagData, error) {


### PR DESCRIPTION
This PR will cause `FlagProvider` to ignore the flag if its value is the default value set as `fd.defaultVal` in favor of allowing the `default` tag to set it. 

This PR would resolve #14.