### PR TITLE
Add a Validation provider

### DIFF
--- a/defaultProvider.go
+++ b/defaultProvider.go
@@ -1,7 +1,6 @@
 package configuration
 
 import (
-	"fmt"
 	"reflect"
 )
 
@@ -14,9 +13,5 @@ type defaultProvider struct{}
 
 func (defaultProvider) Provide(field reflect.StructField, v reflect.Value, _ ...string) error {
 	valStr := getDefaultTag(field)
-	if len(valStr) == 0 {
-		return fmt.Errorf("defaultProvider: getDefaultTag returns empty value")
-	}
-
 	return SetField(field, v, valStr)
 }

--- a/defaultProvider_test.go
+++ b/defaultProvider_test.go
@@ -47,9 +47,9 @@ func TestDefaultProviderPtr(t *testing.T) {
 	}
 }
 
-func TestDefaultProviderFailed(t *testing.T) {
+func TestDefaultProviderEmpty(t *testing.T) {
 	type testStruct struct {
-		Name string
+		Name string `default:""`
 	}
 	testObj := testStruct{}
 
@@ -57,8 +57,10 @@ func TestDefaultProviderFailed(t *testing.T) {
 	fieldVal := reflect.ValueOf(&testObj).Elem().Field(0)
 
 	provider := NewDefaultProvider()
-
-	if err := provider.Provide(fieldType, fieldVal); err == nil {
-		t.Fatal("must not be nil")
+	
+	provider.Provide(fieldType, fieldVal)
+	
+	if !reflect.DeepEqual("", testObj.Name) {
+		t.Fatalf("\nexpected result: [%s] \nbut got: [%s]", "", testObj.Name)
 	}
 }

--- a/flagProvider.go
+++ b/flagProvider.go
@@ -101,8 +101,8 @@ func (fp flagProvider) Provide(field reflect.StructField, v reflect.Value, _ ...
 	}
 
 	val := fn()
-	if len(*val) == 0 {
-		return fmt.Errorf("flagProvider: flag %s returns empty value", fd.key)
+	if *val == fd.defaultVal {
+		return fmt.Errorf("flagProvider: flag %s returns default value", fd.key)
 	}
 	return SetField(field, v, *val)
 }

--- a/flagProvider.go
+++ b/flagProvider.go
@@ -101,6 +101,9 @@ func (fp flagProvider) Provide(field reflect.StructField, v reflect.Value, _ ...
 	}
 
 	val := fn()
+	if len(*val) == 0 {
+		return fmt.Errorf("flagProvider: flag %s returns empty value", fd.key)
+	}
 	return SetField(field, v, *val)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/BoRuDar/configuration/v3
 go 1.14
 
 require (
+	github.com/go-playground/validator/v10 v10.3.0
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,6 +1,8 @@
 package configuration
 
-import "reflect"
+import (
+	"reflect"
+)
 
 // Provider defines interface for existing and future custom providers
 type Provider interface {

--- a/tagGetters.go
+++ b/tagGetters.go
@@ -17,3 +17,7 @@ func getJSONTag(f reflect.StructField) string {
 func getDefaultTag(f reflect.StructField) string {
 	return f.Tag.Get("default")
 }
+
+func getValidateTag(f reflect.StructField) string {
+	return f.Tag.Get("validate")
+}

--- a/validationProvider.go
+++ b/validationProvider.go
@@ -1,0 +1,25 @@
+package configuration
+
+import (
+	"github.com/go-playground/validator/v10"
+	"reflect"
+)
+
+// NewValidationProvider creates new provider which validates the provided value against the validate tag.
+func NewValidationProvider(p Provider) validationProvider {
+	return validationProvider{
+		provider: p,
+	}
+}
+
+type validationProvider struct{
+	provider Provider
+}
+
+func (vP validationProvider) Provide(field reflect.StructField, v reflect.Value, currentPath ...string) error {
+	vP.provider.Provide(field, v, currentPath...)
+
+	valStr := getValidateTag()
+	validate := validator.New()
+	return validate.Var(v.Interface(), valStr)
+}

--- a/validationProvider.go
+++ b/validationProvider.go
@@ -1,11 +1,14 @@
 package configuration
 
 import (
-	"log"
+	"fmt"
 	"reflect"
+	"errors"
 
 	"github.com/go-playground/validator/v10"
 )
+
+var ErrByProvider = errors.New("provider error")
 
 // NewValidationProvider creates new provider which validates the provided value against the validate tag.
 func NewValidationProvider(p Provider) validationProvider {
@@ -19,9 +22,8 @@ type validationProvider struct{
 }
 
 func (vP validationProvider) Provide(field reflect.StructField, v reflect.Value, currentPath ...string) error {
-	err := vP.provider.Provide(field, v, currentPath...)
-	if err != nil {
-		log.Println(err)
+	if err := vP.provider.Provide(field, v, currentPath...); err != nil {
+		return fmt.Errorf("validationProvider: %w, cannot be correct value: %v", ErrByProvider, err)
 	}
 
 	valStr := getValidateTag(field)

--- a/validationProvider.go
+++ b/validationProvider.go
@@ -19,7 +19,7 @@ type validationProvider struct{
 func (vP validationProvider) Provide(field reflect.StructField, v reflect.Value, currentPath ...string) error {
 	vP.provider.Provide(field, v, currentPath...)
 
-	valStr := getValidateTag()
+	valStr := getValidateTag(field)
 	validate := validator.New()
 	return validate.Var(v.Interface(), valStr)
 }

--- a/validationProvider.go
+++ b/validationProvider.go
@@ -1,8 +1,10 @@
 package configuration
 
 import (
-	"github.com/go-playground/validator/v10"
+	"log"
 	"reflect"
+
+	"github.com/go-playground/validator/v10"
 )
 
 // NewValidationProvider creates new provider which validates the provided value against the validate tag.
@@ -17,7 +19,10 @@ type validationProvider struct{
 }
 
 func (vP validationProvider) Provide(field reflect.StructField, v reflect.Value, currentPath ...string) error {
-	vP.provider.Provide(field, v, currentPath...)
+	err := vP.provider.Provide(field, v, currentPath...)
+	if err != nil {
+		log.Println(err)
+	}
 
 	valStr := getValidateTag(field)
 	validate := validator.New()

--- a/validationProvider_test.go
+++ b/validationProvider_test.go
@@ -3,6 +3,7 @@ package configuration
 import (
 	"reflect"
 	"testing"
+	"errors"
 )
 
 func TestValidationProvider(t *testing.T) {
@@ -39,5 +40,25 @@ func TestValidationProviderFail(t *testing.T) {
 
 	if err := provider.Provide(fieldType, fieldVal); err == nil {
 		t.Fatal("must not be nil")
+	}
+}
+
+func TestValidationProviderFailFromProvider(t *testing.T) {
+	type testStruct struct {
+		Name string `validate:"required" env:"TEST_ENV"`
+	}
+	testObj := testStruct{}
+
+	fieldType := reflect.TypeOf(&testObj).Elem().Field(0)
+	fieldVal := reflect.ValueOf(&testObj).Elem().Field(0)
+
+	provider := NewValidationProvider(NewEnvProvider())
+
+	err := provider.Provide(fieldType, fieldVal)
+	if err == nil {
+		t.Fatal("must not be nil")
+	}
+	if !errors.Is(err, ErrByProvider) {
+		t.Fatal("err does not wrap ErrByProvider")
 	}
 }

--- a/validationProvider_test.go
+++ b/validationProvider_test.go
@@ -7,6 +7,27 @@ import (
 
 func TestValidationProvider(t *testing.T) {
 	type testStruct struct {
+		Name string `validate:"required" default:"validation_test"`
+	}
+	testObj := testStruct{}
+
+	fieldType := reflect.TypeOf(&testObj).Elem().Field(0)
+	fieldVal := reflect.ValueOf(&testObj).Elem().Field(0)
+
+	provider := NewValidationProvider(NewDefaultProvider())
+	testValue := "validation_test"
+
+	if err := provider.Provide(fieldType, fieldVal); err != nil {
+		t.Fatal("cannot set value")
+	}
+
+	if !reflect.DeepEqual(testValue, testObj.Name) {
+		t.Fatalf("\nexpected result: [%s] \nbut got: [%s]", testValue, testObj.Name)
+	}
+}
+
+func TestValidationProviderFail(t *testing.T) {
+	type testStruct struct {
 		Name string `validate:"required"`
 	}
 	testObj := testStruct{}
@@ -15,13 +36,8 @@ func TestValidationProvider(t *testing.T) {
 	fieldVal := reflect.ValueOf(&testObj).Elem().Field(0)
 
 	provider := NewValidationProvider(NewDefaultProvider())
-	testValue := "required"
 
-	if err := provider.Provide(fieldType, fieldVal); err != nil {
-		t.Fatal("cannot set value")
-	}
-
-	if !reflect.DeepEqual(testValue, testObj.Name) {
-		t.Fatalf("\nexpected result: [%s] \nbut got: [%s]", testValue, testObj.Name)
+	if err := provider.Provide(fieldType, fieldVal); err == nil {
+		t.Fatal("must not be nil")
 	}
 }

--- a/validationProvider_test.go
+++ b/validationProvider_test.go
@@ -1,0 +1,27 @@
+package configuration
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidationProvider(t *testing.T) {
+	type testStruct struct {
+		Name string `validate:"required"`
+	}
+	testObj := testStruct{}
+
+	fieldType := reflect.TypeOf(&testObj).Elem().Field(0)
+	fieldVal := reflect.ValueOf(&testObj).Elem().Field(0)
+
+	provider := NewValidationProvider(NewDefaultProvider())
+	testValue := "required"
+
+	if err := provider.Provide(fieldType, fieldVal); err != nil {
+		t.Fatal("cannot set value")
+	}
+
+	if !reflect.DeepEqual(testValue, testObj.Name) {
+		t.Fatalf("\nexpected result: [%s] \nbut got: [%s]", testValue, testObj.Name)
+	}
+}


### PR DESCRIPTION
This provider can be used with the `validate` tag to provide validation on a field using [`go-playground/validator`](https://github.com/go-playground/validator). This allows for proper validation, as well as better error checking.

The way this provider works is by wrapping all other providers and if they don't error, it runs the value through `Validate.Var()` and returns the result.
Part of this PR requires that the `defaultProvider` never returns an error, as it's reasonable that a desired default would be a nil value of some sort. This also makes the `flagProvider` error if the retrieved value is the default value. The reason for this, is that if the `flagProvider` is used , all other providers are passed on, because the `flagProvider` never has an empty value.

This PR would resolve #14.