### PR TITLE
[#24] Provide FieldSetter interface to support custom implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Supported types:
 - `uint`, `uint8`, `uint16`, `uint32`, `uint64` + slices of these types
 - `*uint`, `*uint8`, `*uint16`, `*uint32`, `*uint64` + slices of these types
 - `float32`, `float64` + slices of these types
-- `*float32`, `*float64`
+- `*float32`, `*float64` + slices of these types
 - `time.Duration` from strings like `12ms`, `2s` etc.
 - embedded structs and pointers to structs
 
@@ -113,6 +113,30 @@ type Provider interface {
     Name() string
     Init(ptr any) error
     Provide(field reflect.StructField, v reflect.Value) error
+}
+```
+
+### FieldSetter interface
+You can define how to set fields with any custom types: 
+```go
+type FieldSetter interface {
+	SetField(field reflect.StructField, val reflect.Value, valStr string) error
+}
+```
+Example:
+```go
+type ipTest net.IP
+
+func (it *ipTest) SetField(_ reflect.StructField, val reflect.Value, valStr string) error {
+	i := ipTest(net.ParseIP(valStr))
+
+	if val.Kind() == reflect.Pointer {
+		val.Set(reflect.ValueOf(&i))
+	} else {
+		val.Set(reflect.ValueOf(i))
+	}
+
+	return nil
 }
 ```
 

--- a/configurator.go
+++ b/configurator.go
@@ -106,8 +106,7 @@ func (c *Configurator) applyProviders(field reflect.StructField, v reflect.Value
 	}
 
 	for _, provider := range c.providers {
-		err := provider.Provide(field, v)
-		if err == nil {
+		if provider.Provide(field, v) == nil {
 			return
 		}
 	}

--- a/configurator_test.go
+++ b/configurator_test.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -39,7 +40,8 @@ func TestConfigurator(t *testing.T) {
 			IntSlice   []int64  `default:"3; 4"`
 			unexported string   `xml:"ignored"`
 		}
-		URLs []*string `default:"http://localhost:3000;1.2.3.4:8080"`
+		URLs   []*string `default:"http://localhost:3000;1.2.3.4:8080"`
+		HostIP ipTest    `default:"127.0.0.3"`
 	}{}
 
 	configurator := New(
@@ -72,6 +74,8 @@ func TestConfigurator(t *testing.T) {
 	assert(t, []string{"one", "two"}, cfg.Obj.StrSlice)
 	assert(t, []int64{3, 4}, cfg.Obj.IntSlice)
 	assert(t, time.Millisecond*100, cfg.ObjPtr.HundredMS)
+
+	assert(t, net.ParseIP("127.0.0.3"), net.IP(cfg.HostIP))
 
 	for i := range expectedURLs {
 		assert(t, expectedURLs[i], *cfg.URLs[i])


### PR DESCRIPTION
Issue #24 

Allow users to define custom setters for struct fields if following interface is implemented:
```go
type FieldSetter interface {
	SetField(field reflect.StructField, val reflect.Value, valStr string) error
}
```