### PR TITLE
Give better error message on provider application failure.

### DIFF
--- a/configurator.go
+++ b/configurator.go
@@ -105,13 +105,14 @@ func (c *Configurator) applyProviders(field reflect.StructField, v reflect.Value
 		return
 	}
 
+	var lastErr error
 	for _, provider := range c.providers {
-		if provider.Provide(field, v) == nil {
+		if lastErr = provider.Provide(field, v); lastErr == nil {
 			return
 		}
 	}
 
-	c.onErrorFn(fmt.Errorf("configurator: field [%s] with tags [%v] cannot be set", field.Name, field.Tag))
+	c.onErrorFn(fmt.Errorf("configurator: field [%s] with tags [%v] cannot be set. Last Provider error: %s", field.Name, field.Tag, lastErr))
 }
 
 // FromEnvAndDefault is a shortcut for `New(cfg, NewEnvProvider(), NewDefaultProvider()).InitValues()`.

--- a/configurator_test.go
+++ b/configurator_test.go
@@ -153,7 +153,7 @@ func TestSetOnFailFn(t *testing.T) {
 		Name string `default:"test_name"`
 	}{}
 	onFailFn := func(err error) {
-		if err != nil && err.Error() != "configurator: field [Name] with tags [default:\"test_name\"] cannot be set" {
+		if err != nil && err.Error() != "configurator: field [Name] with tags [default:\"test_name\"] cannot be set. Last Provider error: no tag" {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	}

--- a/jsonProvider_test.go
+++ b/jsonProvider_test.go
@@ -107,6 +107,6 @@ func TestFileProvider_Init(t *testing.T) {
 	assert(t, "cannot init [JSONFileProvider] provider: file must have .json extension", err.Error())
 
 	err = New(i, NewJSONFileProvider("./testdata/input.json")).SetOptions(OnFailFnOpt(func(err error) {
-		assert(t, "configurator: field [Test] with tags [file_json:\"void.\"] cannot be set", err.Error())
+		assert(t, "configurator: field [Test] with tags [file_json:\"void.\"] cannot be set. Last Provider error: JSONFileProvider: findValStrByPath returns empty value", err.Error())
 	})).InitValues()
 }


### PR DESCRIPTION
I noticed that when `InitValues()` fails due to no provider finding a value, the error message isn't descriptive. 
This PR proposes outputting the last provider's error message in the error returned by `applyProviders()`. 