### PR TITLE
defaultProvider no longer fails when tag is missing

### DIFF
--- a/defaultProvider.go
+++ b/defaultProvider.go
@@ -24,7 +24,10 @@ func (defaultProvider) Init(_ any) error {
 }
 
 func (dp defaultProvider) Provide(field reflect.StructField, v reflect.Value) error {
-	valStr := field.Tag.Get("default")
+	valStr, ok := field.Tag.Lookup("default")
+	if !ok {
+		return nil
+	}
 	if len(valStr) == 0 {
 		return fmt.Errorf("defaultProvider: %w", ErrEmptyValue)
 	}

--- a/defaultProvider_test.go
+++ b/defaultProvider_test.go
@@ -56,7 +56,7 @@ func TestDefaultProviderFailed(t *testing.T) {
 	t.Parallel()
 
 	type testStruct struct {
-		Name string
+		Name string `default:""`
 	}
 	testObj := testStruct{}
 
@@ -67,5 +67,23 @@ func TestDefaultProviderFailed(t *testing.T) {
 
 	if err := provider.Provide(fieldType, fieldVal); err == nil {
 		t.Fatal("must not be nil")
+	}
+}
+
+func TestDefaultProviderFailedNoTag(t *testing.T) {
+	t.Parallel()
+
+	type testStruct struct {
+		Name string
+	}
+	testObj := testStruct{}
+
+	fieldType := reflect.TypeOf(&testObj).Elem().Field(0)
+	fieldVal := reflect.ValueOf(&testObj).Elem().Field(0)
+
+	provider := NewDefaultProvider()
+
+	if err := provider.Provide(fieldType, fieldVal); err != nil {
+		t.Fatal("must be nil")
 	}
 }


### PR DESCRIPTION
This PR is related to issue #45.

The README seems to indicate that it should be possible to run the defaultProvider (and potentially other providers) on a struct where the relevant tag is missing.

The current behavior is to return ErrEmptyValue if a struct member doesn't have the `default` tag. I'm reading the README so as to believe the current behavior is a bug, and as such needs a fix. If I'm mistaken, please do feel free to disregard this PR ;)

If I'm not mistaken, please do let me know and I won't mind implementing a fix for the other providers.